### PR TITLE
Fixed a buffer overflow in stringByRegex

### DIFF
--- a/src/3rdparty/AFRegexString/AFRegexString.m
+++ b/src/3rdparty/AFRegexString/AFRegexString.m
@@ -91,7 +91,7 @@ int rreplace (char *buf, int size, regex_t *re, char *rp)
 		if(strlen(utf8String) >= sizeof(buffer))
 		    buf = malloc(strlen(utf8String) + 1);
 
-		strcpy(buf, [self UTF8String]);
+		strcpy(buf, utf8String);
 		char *replaceStr = (char*)[substitute UTF8String];
 		
 		if (rreplace (buf, 4096, &preg, replaceStr))


### PR DESCRIPTION
I was running into cases on the internet where the URL was greater than 4096 characters.
I've fixed the problem. This shouldn't impact performance.
