### PR TITLE
Feature/early exit must check if file exist

### DIFF
--- a/src/shared/AFCache.m
+++ b/src/shared/AFCache.m
@@ -347,8 +347,19 @@ static NSMutableDictionary* AFCache_contextCache = nil;
 
     if ([url isFileURL]) {
         AFCacheableItem *shortCircuitItem = [[AFCacheableItem alloc] init];
-        shortCircuitItem.data = [NSData dataWithContentsOfURL: url];
-        if (completionBlock) completionBlock(shortCircuitItem);
+
+        if ([[NSFileManager defaultManager] fileExistsAtPath:[url path]]) {
+            shortCircuitItem.data = [NSData dataWithContentsOfURL: url];
+            if (completionBlock) {
+                completionBlock(shortCircuitItem);
+            }
+        }
+        else {
+            if (failBlock) {
+                failBlock(shortCircuitItem);
+            }
+        }
+        
         return shortCircuitItem;
     }
     


### PR DESCRIPTION
Client wants to be notified by failblock if file does not exist. Returning the completionblock is semantically not correct.
