### PR TITLE
If URL is file URL, URL attribute must be set when returning AFCacheableItem instance

### DIFF
--- a/src/shared/AFCache.m
+++ b/src/shared/AFCache.m
@@ -347,7 +347,7 @@ static NSMutableDictionary* AFCache_contextCache = nil;
 
     if ([url isFileURL]) {
         AFCacheableItem *shortCircuitItem = [[AFCacheableItem alloc] init];
-
+        shortCircuitItem.url = url;
         if ([[NSFileManager defaultManager] fileExistsAtPath:[url path]]) {
             shortCircuitItem.data = [NSData dataWithContentsOfURL: url];
             if (completionBlock) {


### PR DESCRIPTION
If URL is file URL, URL attribute must be set when returning AFCacheableItem instance
