### PR TITLE
Mark operation as finished and non executing when it gets cancelled

### DIFF
--- a/src/shared/AFDownloadOperation.m
+++ b/src/shared/AFDownloadOperation.m
@@ -98,7 +98,7 @@
 }
 
 - (void)cancel {
-    [self.connection cancel];
+    [self finish];
     [super cancel];
 }
 


### PR DESCRIPTION
According to the Apple docs an operation must be marked as finished and non executing when cancelled.

"Specifically, you must change the value returned by finished to YES and the value returned by executing to NO."
(https://developer.apple.com/library/mac/documentation/Cocoa/Reference/NSOperation_class/index.html#//apple_ref/doc/uid/TP40004591-RH2-SW18)